### PR TITLE
Mark Nobl9 Agent secrets as sensitive in Terraform

### DIFF
--- a/modules/nobl9/n9agent/README.md
+++ b/modules/nobl9/n9agent/README.md
@@ -30,7 +30,7 @@ No modules.
 | [aws_iam_user.nobl9-ekg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.nobl9-ekg-ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [helm_release.n9agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_secret.example](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.aws_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [aws_iam_policy_document.nobl9-ekg-ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/modules/nobl9/n9agent/main.tf
+++ b/modules/nobl9/n9agent/main.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_secret" "example" {
+resource "kubernetes_secret" "aws_credentials" {
   metadata {
     name      = var.data_source_name
     namespace = var.namespace

--- a/modules/nobl9/n9agent/variables.tf
+++ b/modules/nobl9/n9agent/variables.tf
@@ -27,9 +27,11 @@ variable "data_source_name" {
 variable "agent_client_id" {
   description = "Client ID of the data source agent (from Nobl9 UI: Integrations > Sources > [your data source] > Agent Configuration)"
   type        = string
+  sensitive   = true
 }
 
 variable "agent_client_secret" {
   description = "Client Secret of the data source agent (from Nobl9 UI: Integrations > Sources > [your data source] > Agent Configuration)"
   type        = string
+  sensitive   = true
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -12,6 +12,8 @@ nobl9_organization_id = "my-nobl9-org-id" # If you don't have a Nobl9 org, sign 
 # You could code those in here, but because they are secrets, we recommend providing those as env vars, e.g.:
 # export TF_VAR_nobl9_client_id="<your Nobl9 Client ID>"
 # export TF_VAR_nobl9_client_secret="<your Nobl9 Client Secret>"
+# or using separate secret.tfvars file for them and ensure it is not checked out in the repository,
+# you can read more about there https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables.
 
 # If you cannot or choose not to run any of the "electrodes", you can use these to skip creating SLOs that require them:
 # (Please note that you may suppress installation of an electrode if you already have it in-cluster, and in that case

--- a/variables.tf
+++ b/variables.tf
@@ -46,9 +46,11 @@ variable "nobl9_project_name" {
 variable "nobl9_client_id" {
   description = "Nobl9 Client ID (create in Nobl9 web app using Settings > Access Keys)"
   type        = string
+  sensitive   = true
 }
 
 variable "nobl9_client_secret" {
   description = "Nobl9 Client Secret (create in Nobl9 web app using Settings > Access Keys)"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
As described in [the docs](https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables) variables that are used for providing secrets can be marked as sensitive to avoid printing them in Terraform logs.

This PR marks Nobl9 Agent credentials as sensitive.